### PR TITLE
Feat: Added config option for adapter and property_presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ You can configure some options by creating an initializer like this:
 Wikidata.configure do |config|
   config.use_only_default_language = false
   config.verbose = true
+  config.faraday_adapter = :typhoeus # default is patron
+  # provide the following methods as easy accessors for
+  # item.entities_for_property_id(:mother)
+  config.property_presets = {
+      mother:   "P25",
+      father:   "P22",
+      children: "P40",
+      doctoral_advisor: "P184"
+    }
   config.client_options = {
     request: {
       open_timeout: 1,

--- a/lib/wikidata/configuration.rb
+++ b/lib/wikidata/configuration.rb
@@ -1,7 +1,7 @@
 module Wikidata
   class Configuration
     class << self
-      attr_accessor :verbose, :use_only_default_language, :client_options
+      attr_accessor :verbose, :use_only_default_language, :client_options, :property_presets, :faraday_adapter
 
       def configure &block
         yield self
@@ -11,5 +11,12 @@ module Wikidata
     @verbose = false
     @use_only_default_language = true
     @client_options = {}
+    @faraday_adapter = :patron
+    @property_presets = {
+      mother:   "P25",
+      father:   "P22",
+      children: "P40",
+      doctoral_advisor: "P184"
+    }
   end
 end

--- a/lib/wikidata/entity.rb
+++ b/lib/wikidata/entity.rb
@@ -131,7 +131,7 @@ module Wikidata
       Faraday.new({url: BASE_URL}.merge(Wikidata.client_options)) do |faraday|
         faraday.request  :url_encoded
         faraday.response :json, :content_type => /\bjson$/
-        faraday.adapter  :patron
+        faraday.adapter  Wikidata::Configuration.faraday_adapter
       end
     end
 

--- a/lib/wikidata/item.rb
+++ b/lib/wikidata/item.rb
@@ -29,12 +29,7 @@ module Wikidata
     end
 
     def entities_for_property_id(property_id)
-      presets = {
-        mother:   "P25",
-        father:   "P22",
-        children: "P40",
-        doctoral_advisor: "P184"
-      }
+      presets = Wikidata::Configuration.property_presets
       property_id = presets[property_id.to_sym] if presets.include?(property_id.to_sym)
       claims_for_property_id(property_id).map{|c| c.mainsnak.value.entity }
     rescue


### PR DESCRIPTION
- Enables changing the default adapter (I've found patron having problems with thead safety https://github.com/toland/patron#threading, thus can be exchanged by e.g. Typhoeus)
- Also put the property presets of family tree in a config option to add one own's