### PR TITLE
Handle somevalue and novalue snaktypes with dedicated value classes

### DIFF
--- a/lib/wikidata.rb
+++ b/lib/wikidata.rb
@@ -18,6 +18,8 @@ require "wikidata/datavalues/time"
 require "wikidata/datavalues/globecoordinate"
 require "wikidata/datavalues/entity"
 require "wikidata/datavalues/year"
+require "wikidata/datavalues/some_value"
+require "wikidata/datavalues/no_value"
 
 module Wikidata
   class << self

--- a/lib/wikidata/datavalues/no_value.rb
+++ b/lib/wikidata/datavalues/no_value.rb
@@ -1,0 +1,9 @@
+module Wikidata
+  module DataValues
+    class NoValue < Wikidata::DataValues::Value
+      def to_s
+        "No value"
+      end
+    end
+  end
+end

--- a/lib/wikidata/datavalues/some_value.rb
+++ b/lib/wikidata/datavalues/some_value.rb
@@ -1,0 +1,9 @@
+module Wikidata
+  module DataValues
+    class SomeValue < Wikidata::DataValues::Value
+      def to_s
+        "Unknown value"
+      end
+    end
+  end
+end

--- a/lib/wikidata/snak.rb
+++ b/lib/wikidata/snak.rb
@@ -8,8 +8,24 @@ module Wikidata
       @property ||= Wikidata::Property.find_by_id(property_id)
     end
 
+    def no_value?
+      @data_hash["snaktype"] == "novalue"
+    end
+
+    def some_value?
+      @data_hash["snaktype"] == "somevalue"
+    end
+
+    def unknown?
+      no_value? || some_value?
+    end
+
     def value
-      @value ||= if @data_hash["snaktype"] == "novalue" || @data_hash["snaktype"] == "somevalue" || @data_hash["datavalue"].nil?
+      @value ||= if @data_hash["snaktype"] == "novalue"
+        Wikidata::DataValues::NoValue.new({})
+      elsif @data_hash["snaktype"] == "somevalue"
+        Wikidata::DataValues::SomeValue.new({})
+      elsif @data_hash["datavalue"].nil?
         nil
       elsif datavalue["type"] == "wikibase-entityid"
         Wikidata::DataValues::Entity.new(datavalue.value)

--- a/spec/wikidata/datavalues_spec.rb
+++ b/spec/wikidata/datavalues_spec.rb
@@ -80,3 +80,17 @@ class DataValuesCommonsMediaTest < Minitest::Test
     assert_includes val.url(width: 300), "width=300"
   end
 end
+
+class DataValuesSomeValueTest < Minitest::Test
+  def test_to_s
+    val = Wikidata::DataValues::SomeValue.new({})
+    assert_equal "Unknown value", val.to_s
+  end
+end
+
+class DataValuesNoValueTest < Minitest::Test
+  def test_to_s
+    val = Wikidata::DataValues::NoValue.new({})
+    assert_equal "No value", val.to_s
+  end
+end

--- a/spec/wikidata/snak_spec.rb
+++ b/spec/wikidata/snak_spec.rb
@@ -85,14 +85,52 @@ class SnakTest < Minitest::Test
     assert_includes snak.value.url, "LA+Skyline+Mountains2.jpg"
   end
 
-  def test_novalue_returns_nil
+  def test_novalue_returns_no_value_object
     snak = make_snak("snaktype" => "novalue", "property" => "P40")
-    assert_nil snak.value
+    assert_instance_of Wikidata::DataValues::NoValue, snak.value
+    assert_equal "No value", snak.value.to_s
   end
 
-  def test_somevalue_returns_nil
+  def test_somevalue_returns_some_value_object
     snak = make_snak("snaktype" => "somevalue", "property" => "P1082")
-    assert_nil snak.value
+    assert_instance_of Wikidata::DataValues::SomeValue, snak.value
+    assert_equal "Unknown value", snak.value.to_s
+  end
+
+  def test_no_value_predicate
+    novalue_snak = make_snak("snaktype" => "novalue", "property" => "P40")
+    assert novalue_snak.no_value?
+
+    value_snak = make_snak("snaktype" => "value", "property" => "P31", "datavalue" => {
+      "value" => {"entity-type" => "item", "numeric-id" => 515},
+      "type" => "wikibase-entityid"
+    })
+    refute value_snak.no_value?
+  end
+
+  def test_some_value_predicate
+    somevalue_snak = make_snak("snaktype" => "somevalue", "property" => "P1082")
+    assert somevalue_snak.some_value?
+
+    value_snak = make_snak("snaktype" => "value", "property" => "P31", "datavalue" => {
+      "value" => {"entity-type" => "item", "numeric-id" => 515},
+      "type" => "wikibase-entityid"
+    })
+    refute value_snak.some_value?
+  end
+
+  def test_unknown_predicate
+    novalue_snak = make_snak("snaktype" => "novalue", "property" => "P40")
+    assert novalue_snak.unknown?
+
+    somevalue_snak = make_snak("snaktype" => "somevalue", "property" => "P1082")
+    assert somevalue_snak.unknown?
+
+    value_snak = make_snak("snaktype" => "value", "property" => "P31", "datavalue" => {
+      "value" => {"entity-type" => "item", "numeric-id" => 515},
+      "type" => "wikibase-entityid"
+    })
+    refute value_snak.unknown?
   end
 
   def test_nil_datavalue_returns_nil


### PR DESCRIPTION
## Summary

- Introduces `Wikidata::DataValues::SomeValue` and `Wikidata::DataValues::NoValue` classes that inherit from `Wikidata::DataValues::Value`, replacing the previous behavior of returning `nil` for both `somevalue` and `novalue` snaktypes in `Snak#value`.
- Adds `Snak#no_value?`, `Snak#some_value?`, and `Snak#unknown?` predicate methods for easy snaktype checking.
- Supersedes #9, which proposed returning a `DataValues::String` with `"Unknown"` — that approach conflated unknown values with string types.

## Motivation

Wikidata distinguishes between two special snaktypes:

- **`novalue`** — the property explicitly has no value (e.g., Elizabeth I has no spouse)
- **`somevalue`** — a value exists but is unknown (e.g., a person has a birth date but it's not known)

Previously, both returned `nil`, making it impossible for callers to distinguish between these semantically different cases (or to distinguish them from a missing datavalue).

## Usage

```ruby
snak = item.claims("P26").first.mainsnak

# Predicate methods
snak.no_value?   # => true if snaktype is "novalue"
snak.some_value?  # => true if snaktype is "somevalue"
snak.unknown?     # => true if either no_value? or some_value?

# Value objects with meaningful string representations
snak.value.to_s   # => "No value" or "Unknown value"

# Type checking
snak.value.is_a?(Wikidata::DataValues::NoValue)   # => true
snak.value.is_a?(Wikidata::DataValues::SomeValue)  # => true
snak.value.is_a?(Wikidata::DataValues::Value)      # => true (both inherit from Value)
```

## Test plan

- [ ] Verify `Snak#value` returns a `NoValue` instance when snaktype is `"novalue"`
- [ ] Verify `Snak#value` returns a `SomeValue` instance when snaktype is `"somevalue"`
- [ ] Verify `Snak#value` still returns `nil` when datavalue is nil (but snaktype is normal)
- [ ] Verify `NoValue#to_s` returns `"No value"`
- [ ] Verify `SomeValue#to_s` returns `"Unknown value"`
- [ ] Verify `no_value?`, `some_value?`, and `unknown?` predicates return correct booleans
- [ ] Verify existing value resolution (entities, times, strings, etc.) is unchanged